### PR TITLE
chore: update Github CI with living Rails 7.2 version

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu, macos]
         ruby-version: ['3.3', '3.4']
-        rails-version: ['7.1', '8']
+        rails-version: ['7.2', '8']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
As Rails `7.1` is going to be ended soon, see https://endoflife.date/rails 

<img width="737" height="292" alt="Screenshot 2025-08-21 at 10 36 03" src="https://github.com/user-attachments/assets/ab3116a0-5a04-4316-b8e8-4c4887e586a6" />
